### PR TITLE
load datasets using require-r

### DIFF
--- a/src/clojuress/v1/impl/rserve/java_to_clj.clj
+++ b/src/clojuress/v1/impl/rserve/java_to_clj.clj
@@ -1,6 +1,5 @@
 (ns clojuress.v1.impl.rserve.java-to-clj
   (:require [clojure.walk :as walk]
-            [com.rpl.specter :as specter]
             [tech.ml.dataset :as dataset]
             [tech.v2.datatype.protocols :as dtype-prot :refer [->array-copy]]
             [clojure.math.combinatorics :refer [cartesian-product]])
@@ -24,12 +23,8 @@
                     (.asNativeJavaObject))}
        (walk/prewalk (fn [v]
                        (if (instance? Map v)
-                         (->> v
-                              (into {})
-                              (specter/transform [specter/MAP-KEYS]
-                                                 keyword))
+                         (into {} v)
                          v)))))
-
 
 (extend-type REXPDouble
   dtype-prot/PToArray
@@ -186,9 +181,8 @@
   Clojable
   (-java->clj [java-obj]
     (let [names  (some-> java-obj
-                          (.getAttribute "names")
-                          ->array-copy
-                          (->> (map keyword)))
+                         (.getAttribute "names")
+                         ->array-copy)
           values (->> java-obj
                       (.asList)
                       ;; Convert list elements recursively.

--- a/src/clojuress/v1/require.clj
+++ b/src/clojuress/v1/require.clj
@@ -31,8 +31,8 @@
                              session)))
          using-sessions/r->java
          (prot/java->clj session)
-         (filter (fn [function-name]
-                   (re-matches #"[A-Za-z][A-Za-z\\.\\_].*" function-name)))
+         (remove (fn [function-name]
+                   (re-matches #"[\Q[](){}#@;:,\/`^'~\"\E].*" function-name)))
          (map symbol))))
 
 (defn all-r-symbols-map [package-symbol]

--- a/src/clojuress/v1/require.clj
+++ b/src/clojuress/v1/require.clj
@@ -7,46 +7,57 @@
             [clojuress.v1.util :as util
              :refer [l clojurize-r-symbol]]))
 
-(defn package-function
-  [package-symbol function-symbol]
-  (let [delayed (delay (functions/function
-                        (evl/r (format "{%s::`%s`}"
-                                       (name package-symbol)
-                                       (name function-symbol))
-                               (session/fetch-or-make nil))))]
+(defn package-object [package-symbol object-symbol]
+  (evl/r (format "{%s::`%s`}"
+                 (name package-symbol)
+                 (name object-symbol))
+         (session/fetch-or-make nil)))
+
+(defn package-function [package-symbol function-symbol]
+  (let [delayed (delay (functions/function (package-object package-symbol function-symbol)))]
     (fn [& args]
       (apply @delayed args))))
 
-(defn package-symbol->all-functions-symbols [package-symbol]
+(defn package-dataset [package-symbol dataset-symbol]
+  (package-object package-symbol dataset-symbol))
+
+(defn package-symbol->r-symbols [r-selector-function package-symbol]
   (let [session (session/fetch-or-make nil)]
     (->> package-symbol
          name
-         vector
-         (#(functions/apply-function
-            (evl/r "function(package_name) as.character(unlist(lsf.str(paste0('package:', package_name))))"
-                   session)
-            %
-            session))
+         ((fn [package-name] (functions/apply-function
+                             (evl/r r-selector-function session)
+                             [package-name]
+                             session)))
          using-sessions/r->java
          (prot/java->clj session)
          (filter (fn [function-name]
                    (re-matches #"[A-Za-z][A-Za-z\\.\\_].*" function-name)))
-         (map symbol))))
+         (map symbol)
+         (set))))
+
+(def package-symbol->all-functions-symbols
+  (partial package-symbol->r-symbols "function(package_name) as.character(unlist(lsf.str(paste0('package:', package_name))))"))
+
+(def package-symbol->all-datasets-symbols
+  (partial package-symbol->r-symbols "function(package_name) data(package=package_name)$results[,'Item']"))
 
 (defn find-or-create-ns [ns-symbol]
- (or (find-ns ns-symbol)
-     (create-ns ns-symbol)))
+  (or (find-ns ns-symbol)
+      (create-ns ns-symbol)))
 
-(defn add-function-to-ns [ns-symbol package-symbol function-symbol]
+(defn add-to-ns [wrapper ns-symbol package-symbol r-symbol]
   (intern ns-symbol
-          (clojurize-r-symbol function-symbol)
-          (package-function package-symbol function-symbol)))
+          (clojurize-r-symbol r-symbol)
+          (wrapper package-symbol r-symbol)))
 
-(defn ->this-ns-symbol []
-  (-> *ns* str symbol))
+(defn symbols->add-to-ns [ns-symbol package-symbol dataset-symbols function-symbols]
+  (doseq [function-symbol function-symbols]
+    (add-to-ns package-function ns-symbol package-symbol function-symbol))
+  (doseq [dataset-symbol dataset-symbols]
+    (add-to-ns package-dataset ns-symbol package-symbol dataset-symbol)))
 
-(defn require-r-package [[package-symbol
-                          & {:keys [as refer]}]]
+(defn require-r-package [[package-symbol & {:keys [as refer]}]]
   (let [session (session/fetch-or-make nil)]
     (evl/eval-form (l 'library
                       package-symbol)
@@ -54,20 +65,25 @@
   (let [r-ns-symbol (->> package-symbol
                          (str "r.")
                          symbol)
-        this-ns-symbol (->this-ns-symbol)
-        function-symbols (package-symbol->all-functions-symbols
-                          package-symbol)]
+        dataset-symbols (package-symbol->all-datasets-symbols package-symbol)
+        function-symbols (package-symbol->all-functions-symbols package-symbol)]
+
+    ;; r.package namespace
     (find-or-create-ns r-ns-symbol)
-    (doseq [function-symbol function-symbols]
-      (add-function-to-ns r-ns-symbol package-symbol function-symbol))
+    (symbols->add-to-ns r-ns-symbol package-symbol dataset-symbols function-symbols)
+
+    ;; alias namespace
     (when as
       (find-or-create-ns as)
-      (doseq [function-symbol function-symbols]
-        (add-function-to-ns as package-symbol function-symbol)))
+      (symbols->add-to-ns as package-symbol dataset-symbols function-symbols))
+
+    ;; inject symbol into current namespace
     (when refer
-      (doseq [function-symbol refer]
-        (add-function-to-ns this-ns-symbol package-symbol function-symbol)))))
+      (let [refer-set (set refer)
+            this-ns-symbol (-> *ns* str symbol)]
+        (symbols->add-to-ns this-ns-symbol package-symbol
+                            (clojure.set/intersection refer-set dataset-symbols)
+                            (clojure.set/intersection refer-set function-symbols))))))
 
 (defn require-r [& packages]
-  (mapv require-r-package packages))
-
+  (run! require-r-package packages))


### PR DESCRIPTION
As discussed on Zulip.

Datasets are loaded as symbols using `require-r`. Dataset is bound to RObject. All below works well:

```
(require-r '[paletteer :as pal :refer [palettes_c_names]])

palettes_c_names
r.paletteer/palettes_c_names
pal/palettes_c_names

(class (r->clj palettes_c_names))
;; => tech.ml.dataset.generic_columnar_dataset.GenericColumnarDataset
```